### PR TITLE
Handle Flatpak Better

### DIFF
--- a/eepresetselector@ulville.github.io/extension.js
+++ b/eepresetselector@ulville.github.io/extension.js
@@ -36,7 +36,7 @@ const Me = ExtensionUtils.getCurrentExtension();
 const EEPSIndicator = GObject.registerClass(
     class EEPSIndicator extends PanelMenu.Button {
         _init() {
-            super._init(0.0, _("EasyEffects Preset Selector"));
+            super._init(0.5, _("EasyEffects Preset Selector"));
 
             this.categoryNames, this.outputPresets, this.inputPresets;
 
@@ -61,9 +61,6 @@ const EEPSIndicator = GObject.registerClass(
                 if (await succesful) {
                     await new Promise((r) => setTimeout(r, 500));
                     this._refreshMenu();
-                    // log(_("Done loading and refreshing"));
-                    // let txts = await this.getLastPresets("flatpak");
-                    // log(_(txts.join("\n")));
                 }
             } catch (error) {
                 Main.notify(

--- a/eepresetselector@ulville.github.io/extension.js
+++ b/eepresetselector@ulville.github.io/extension.js
@@ -56,7 +56,7 @@ const EEPSIndicator = GObject.registerClass(
             this._refreshMenu();
         }
 
-        async _loadPreset(preset, command_arr) {
+        _loadPreset(preset, command_arr) {
             let argument = preset.replace(" ", "\\ ").replace("'", "\\'");
             let command_str = command_arr.concat(["-l"]).join(" ") + " ";
 


### PR DESCRIPTION
- Flatpak version of EasyEffects has some delay between loading a preset and updating "last-used-*-preset" values in dconf. This was causing problems if you click the panel button too quick after loading a preset. Now we save the last selected preset and ornament that item. When you click to the panelbutton after that if it's too quick we wait a little bit more to read actual last used preset value. 

- Also reading available and last used presets fails at random times (for flatpak version) and it gives a spesific warning message. Now we just try again if that's the case.

- It also center aligns the menu to the panel button