### PR TITLE
Scrollable PopupMenuSection

### DIFF
--- a/eepresetselector@ulville.github.io/extension.js
+++ b/eepresetselector@ulville.github.io/extension.js
@@ -108,8 +108,7 @@ const EEPSIndicator = GObject.registerClass(
             // Create scrollable MenuSection for Output Presets
             let _outputScrollSection = new PopupMenu.PopupMenuSection();
             let _outputScrollView = new St.ScrollView({
-                style_class: 'scroll-menu-section',
-                overlay_scrollbars: true,
+                overlay_scrollbars: false,
             });
             let _outputSection = new PopupMenu.PopupMenuSection();
             _outputScrollView.add_actor(_outputSection.actor);
@@ -148,10 +147,8 @@ const EEPSIndicator = GObject.registerClass(
             // Create scrollable PopupMenuSection for Input Presets
             let _inputScrollSection = new PopupMenu.PopupMenuSection();
             let _inputScrollView = new St.ScrollView({
-                style_class: 'scroll-menu-section',
-                overlay_scrollbars: true,
+                overlay_scrollbars: false,
             });
-            _inputScrollView.add_style_class_name('scroll-menu-section');
             let _inputSection = new PopupMenu.PopupMenuSection();
             _inputScrollView.add_actor(_inputSection.actor);
             _inputScrollSection.actor.add_actor(_inputScrollView);
@@ -170,6 +167,25 @@ const EEPSIndicator = GObject.registerClass(
             });
 
             this.menu.addMenuItem(_inputScrollSection);
+
+            // Arrage scrollbar policies
+            let _menuThemeNode = this.menu.actor.get_theme_node();
+            let _maxHeight = _menuThemeNode.get_max_height();
+            let [, _titleNaturalHeight] = this.menu.firstMenuItem.actor.get_preferred_height(-1);
+            let [, _outputNaturalHeight] = _outputSection.actor.get_preferred_height(-1);
+            let [, _inputNaturalHeight] = _inputSection.actor.get_preferred_height(-1);
+
+            let _notFillsScreen = _maxHeight >= 0 && _inputNaturalHeight + _outputNaturalHeight + 2 * _titleNaturalHeight <= _maxHeight;
+            if (_notFillsScreen) {
+                _inputScrollView.vscrollbar_policy = St.PolicyType.NEVER;
+                _outputScrollView.vscrollbar_policy = St.PolicyType.NEVER;
+            } else {
+                let _outputNeedsScrollbar = _maxHeight >= 0 && _outputNaturalHeight + _titleNaturalHeight >= _maxHeight / 2;
+                _outputScrollView.vscrollbar_policy = _outputNeedsScrollbar ? St.PolicyType.AUTOMATIC : St.PolicyType.NEVER;
+
+                let _inputNeedsScrollbar = _maxHeight >= 0 && _inputNaturalHeight + _titleNaturalHeight >= _maxHeight / 2;
+                _inputScrollView.vscrollbar_policy = _inputNeedsScrollbar ? St.PolicyType.AUTOMATIC : St.PolicyType.NEVER;
+            }
         }
 
         async _refreshMenu() {

--- a/eepresetselector@ulville.github.io/extension.js
+++ b/eepresetselector@ulville.github.io/extension.js
@@ -105,6 +105,15 @@ const EEPSIndicator = GObject.registerClass(
                 _outputTitle.add_child(_inputIcon);
                 this.menu.addMenuItem(_outputTitle);
             }
+            // Create scrollable MenuSection for Output Presets
+            let _outputScrollSection = new PopupMenu.PopupMenuSection();
+            let _outputScrollView = new St.ScrollView({
+                style_class: 'scroll-menu-section',
+                overlay_scrollbars: true,
+            });
+            let _outputSection = new PopupMenu.PopupMenuSection();
+            _outputScrollView.add_actor(_outputSection.actor);
+            _outputScrollSection.actor.add_actor(_outputScrollView);
 
             // Add a menu item to menu for each output preset and connect it to easyeffects' load preset command
             outputPresets.forEach(element => {
@@ -114,10 +123,12 @@ const EEPSIndicator = GObject.registerClass(
 
                 _menuItem.connect('activate', () => {
                     this._loadPreset(element, command);
+                    this.menu.toggle();
                 });
-                this.menu.addMenuItem(_menuItem);
+                _outputSection.addMenuItem(_menuItem);
             });
 
+            this.menu.addMenuItem(_outputScrollSection);
 
             // Category Title: "Input Presets" (As how the command did output it)
             if (inputCategoryName) {
@@ -134,6 +145,17 @@ const EEPSIndicator = GObject.registerClass(
                 this.menu.addMenuItem(_inputTitle);
             }
 
+            // Create scrollable PopupMenuSection for Input Presets
+            let _inputScrollSection = new PopupMenu.PopupMenuSection();
+            let _inputScrollView = new St.ScrollView({
+                style_class: 'scroll-menu-section',
+                overlay_scrollbars: true,
+            });
+            _inputScrollView.add_style_class_name('scroll-menu-section');
+            let _inputSection = new PopupMenu.PopupMenuSection();
+            _inputScrollView.add_actor(_inputSection.actor);
+            _inputScrollSection.actor.add_actor(_inputScrollView);
+
             // Add a menu item to menu for each input preset and connect it to easyeffects' load preset command
             inputPresets.forEach(element => {
                 let _menuItem = new PopupMenu.PopupMenuItem(_(element));
@@ -142,9 +164,12 @@ const EEPSIndicator = GObject.registerClass(
 
                 _menuItem.connect('activate', () => {
                     this._loadPreset(element, command);
+                    this.menu.toggle();
                 });
-                this.menu.addMenuItem(_menuItem);
+                _inputSection.addMenuItem(_menuItem);
             });
+
+            this.menu.addMenuItem(_inputScrollSection);
         }
 
         async _refreshMenu() {

--- a/eepresetselector@ulville.github.io/stylesheet.css
+++ b/eepresetselector@ulville.github.io/stylesheet.css
@@ -2,7 +2,3 @@
 .preset-title-item {
     font-weight: bold;
 }
-
-.scroll-menu-section {
-    max-height: 250px;
-}

--- a/eepresetselector@ulville.github.io/stylesheet.css
+++ b/eepresetselector@ulville.github.io/stylesheet.css
@@ -2,3 +2,7 @@
 .preset-title-item {
     font-weight: bold;
 }
+
+.scroll-menu-section {
+    max-height: 250px;
+}


### PR DESCRIPTION
I don't know if it will ever be relevant but if someone has a ton of Presets, the list would overflow the screen area. _Could be useful for low resolution screens_.

This measures the max available size for the list and uses a scrollable menu section in case of an overflow.