### PR TITLE
Gnome45 support

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -20,3 +20,6 @@ install:
 
 translations:
 	./update-locale.sh
+
+pot:
+	./update-locale.sh -a

--- a/Makefile
+++ b/Makefile
@@ -1,19 +1,22 @@
-uuid = eepresetselector@ulville.github.io
-install_dir = ~/.local/share/gnome-shell/extensions
+BUNDLE_PATH = "eepresetselector@ulville.github.io.zip"
+EXTENSION_DIR = "eepresetselector@ulville.github.io"
 
 all: build install
 
-.PHONY: build install dist
+.PHONY: build install translations
 
 build:
-	./update-locale.sh
-	glib-compile-schemas --strict $(uuid)/schemas
-
-dist: build
-	rm -f $(uuid).zip
-	cd $(uuid) && zip -r ../$(uuid).zip ./* --exclude \*.po
+	rm -f $(BUNDLE_PATH)
+	cd $(EXTENSION_DIR); \
+	gnome-extensions pack --force --podir=locale \
+	                      --extra-source=preferences/ \
+	                      --extra-source=icons/ \
+	                      --extra-source=COPYING; \
+	mv $(EXTENSION_DIR).shell-extension.zip ../$(BUNDLE_PATH)
 
 install:
-	install -d $(install_dir)
-	cp -a $(uuid)/ $(install_dir)/
+	gnome-extensions install $(BUNDLE_PATH) --force
 	@echo "Extension installed. Re-login to start using it"
+
+translations:
+	./update-locale.sh

--- a/README.md
+++ b/README.md
@@ -91,8 +91,31 @@ make
 
 ## Language Support
 
-The extension shows text as parsed from the output of EasyEffects' command-line interface so it already comes in the system language (If supported by EasyEffects).
+The extension shows 'Output Preset' and 'Input Preset' title names as parsed from the output of EasyEffects' command-line interface so it already comes in the system language (If supported by EasyEffects).
 
 <p align="center">
     <img src="./screenshots/screenshot-turkish.png" alt="When system language set to Turkish">
 </p>
+
+For notifications and preferences we need translations. Available translations are:
+
+- Turkish
+
+## Translators
+
+### To add a new language:
+
+1. Create an up-to-date template file:
+```
+make pot
+```
+2. Open it using your favorite PO editor e.g. "Poedit". Create a translation from it for your language, make your changes and save it as a .po file in `./locale` directory.
+3. Remove the .pot file
+
+### To improve an existing translation
+
+1. Update translatable messages by running
+```
+make translations
+```
+2. Edit the PO file you want to work on using your favorite PO editor and save.

--- a/README.md
+++ b/README.md
@@ -51,9 +51,16 @@ To fix some of the common problems you might possibly have after installing the 
 
 -   Note: Because of the review process, new versions on the GNOME Extensions Website may lag a few days behind sometimes.
 
+### Versions
 
+Extensions developed for GNOME 45+ is incompatible with older GNOME versions and vice-versa. If you use GNOME Extensions Website or some application like Extension Manager it should install the latest compatible version for your GNOME version. But if you'll install it from source you should pick the one that is compatible with your GNOME version.
 
-### Install Script
+| Branch | Version | Compatible GNOME Version |
+| ------ | ------- | ------------------------ |
+| master | v18     | GNOME 45 +               |
+| legacy | v17     | GNOME 3.38 -> GNOME 45   |  |
+
+### Installation From source
 
 1.   Clone the repository:
 
@@ -63,7 +70,13 @@ git clone https://github.com/ulville/eepresetselector.git
 ```
 cd eepresetselector
 ```
-2.   Run install script:
+2.  If you need a specific version rather than the master branch:
+```
+git checkout <tag-or-branch>
+```
+Replace `<tag-or-branch>` with the version's tag name e.g. `git checkout v17` or a branch name e.g. `git checkout legacy`
+
+3.   Run install script:
 
 ```
 make

--- a/README.md
+++ b/README.md
@@ -46,7 +46,7 @@ To fix some of the common problems you might possibly have after installing the 
 
 -   To be able to install extensions from extensions website, you need to have:
 
-    1. `chrome-gnome-shell` package (from your package manager) (regardless of what you use as browser firefox or chromium based this package works for all of them)
+    1. `gnome-browser-connector` package (from your package manager)
     2. GNOME Shell Integration add-on for your browser - [for chromium](https://chrome.google.com/webstore/detail/gnome-shell-integration/gphhapmejobijbbhgpjhcjognlahblep) , [for firefox](https://addons.mozilla.org/tr/firefox/addon/gnome-shell-integration/)
 
 -   Note: Because of the review process, new versions on the GNOME Extensions Website may lag a few days behind sometimes.

--- a/eepresetselector@ulville.github.io/extension.js
+++ b/eepresetselector@ulville.github.io/extension.js
@@ -20,22 +20,33 @@
 
 /* exported init */
 
-const GETTEXT_DOMAIN = 'gnome-shell-extension-eepresetselector';
+// const GETTEXT_DOMAIN = 'gnome-shell-extension-eepresetselector';
 
-const {GObject, St, GLib, Gio, Shell, Clutter, Meta} = imports.gi;
+// const {GObject, St, GLib, Gio, Shell, Clutter, Meta} = imports.gi;
 
-const ExtensionUtils = imports.misc.extensionUtils;
-const Main = imports.ui.main;
-const PanelMenu = imports.ui.panelMenu;
-const PopupMenu = imports.ui.popupMenu;
-const _ = ExtensionUtils.gettext;
-const Me = ExtensionUtils.getCurrentExtension();
+import GObject from 'gi://GObject';
+import St from 'gi://St';
+import GLib from 'gi://GLib';
+import Gio from 'gi://Gio';
+import Shell from 'gi://Shell';
+import Clutter from 'gi://Clutter';
+import Meta from 'gi://Meta';
+
+import {Extension, gettext as _} from 'resource:///org/gnome/shell/extensions/extension.js';
+// const ExtensionUtils = imports.misc.extensionUtils;
+// const Main = imports.ui.main;
+import * as Main from 'resource:///org/gnome/shell/ui/main.js';
+// const PanelMenu = imports.ui.panelMenu;
+import * as PanelMenu from 'resource:///org/gnome/shell/ui/panelMenu.js';
+// const PopupMenu = imports.ui.popupMenu;
+import * as PopupMenu from 'resource:///org/gnome/shell/ui/popupMenu.js';
+// const Me = ExtensionUtils.getCurrentExtension();
 
 let sourceId = null;
 
 const EEPSIndicator = GObject.registerClass(
     class EEPSIndicator extends PanelMenu.Button {
-        _init() {
+        _init(settings, path) {
             super._init(0.5, _('EasyEffects Preset Selector'));
 
             this.categoryNames = [' ', ' '];
@@ -45,7 +56,7 @@ const EEPSIndicator = GObject.registerClass(
             this.lastUsedOutputPreset = ' ';
             this.lastPresetLoadTime = 0;
             this.command = [];
-            this.settings = ExtensionUtils.getSettings();
+            this.settings = settings;
 
             Main.wm.addKeybinding(
                 'cycle-output-presets',
@@ -62,7 +73,7 @@ const EEPSIndicator = GObject.registerClass(
 
             this._icon = new St.Icon({style_class: 'system-status-icon'});
             this._icon.gicon = Gio.icon_new_for_string(
-                `${Me.path}/icons/eepresetselector-symbolic.svg`
+                `${path}/icons/eepresetselector-symbolic.svg`
             );
             this.add_child(this._icon);
             this.connect('button-press-event', () => {
@@ -459,16 +470,11 @@ const EEPSIndicator = GObject.registerClass(
     }
 );
 
-class Extension {
-    constructor(uuid) {
-        this._uuid = uuid;
-
-        ExtensionUtils.initTranslations(GETTEXT_DOMAIN);
-    }
-
+export default class EEPSExtension extends Extension {
     enable() {
-        this._indicator = new EEPSIndicator();
-        Main.panel.addToStatusArea(this._uuid, this._indicator);
+        this._settings = this.getSettings();
+        this._indicator = new EEPSIndicator(this._settings, this.path);
+        Main.panel.addToStatusArea(this.uuid, this._indicator);
     }
 
     disable() {
@@ -480,11 +486,6 @@ class Extension {
         Main.wm.removeKeybinding('cycle-input-presets');
         this._indicator.destroy();
         this._indicator = null;
-        this.settings = null;
+        this._settings = null;
     }
-}
-
-// eslint-disable-next-line jsdoc/require-jsdoc
-function init(meta) {
-    return new Extension(meta.uuid);
 }

--- a/eepresetselector@ulville.github.io/extension.js
+++ b/eepresetselector@ulville.github.io/extension.js
@@ -18,11 +18,7 @@
 
 /* Copyright Ulvican Kahya aka ulville 2022 */
 
-/* exported init */
-
-// const GETTEXT_DOMAIN = 'gnome-shell-extension-eepresetselector';
-
-// const {GObject, St, GLib, Gio, Shell, Clutter, Meta} = imports.gi;
+/* exported EEPSExtension */
 
 import GObject from 'gi://GObject';
 import St from 'gi://St';
@@ -33,14 +29,9 @@ import Clutter from 'gi://Clutter';
 import Meta from 'gi://Meta';
 
 import {Extension, gettext as _} from 'resource:///org/gnome/shell/extensions/extension.js';
-// const ExtensionUtils = imports.misc.extensionUtils;
-// const Main = imports.ui.main;
 import * as Main from 'resource:///org/gnome/shell/ui/main.js';
-// const PanelMenu = imports.ui.panelMenu;
 import * as PanelMenu from 'resource:///org/gnome/shell/ui/panelMenu.js';
-// const PopupMenu = imports.ui.popupMenu;
 import * as PopupMenu from 'resource:///org/gnome/shell/ui/popupMenu.js';
-// const Me = ExtensionUtils.getCurrentExtension();
 
 let sourceId = null;
 

--- a/eepresetselector@ulville.github.io/locale/tr.po
+++ b/eepresetselector@ulville.github.io/locale/tr.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: \n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2023-06-05 22:52+0300\n"
+"POT-Creation-Date: 2023-09-09 18:58+0300\n"
 "PO-Revision-Date: 2023-06-05 04:40+0300\n"
 "Last-Translator: \n"
 "Language-Team: \n"
@@ -17,55 +17,55 @@ msgstr ""
 "Content-Transfer-Encoding: 8bit\n"
 "X-Generator: Poedit 3.3.1\n"
 
-#: extension.js:39
+#: extension.js:41
 msgid "EasyEffects Preset Selector"
 msgstr "EasyEffects Ön Ayar Seçici"
 
-#: extension.js:109
+#: extension.js:111
 msgid "An error occurred while trying to load the preset"
 msgstr "Ön ayarı yüklemeye çalışırken bir hata meydana geldi"
 
-#: extension.js:205 extension.js:208
+#: extension.js:207 extension.js:210
 msgid "EasyEffects isn't available on the system"
 msgstr "EasyEffects sistemde mevcut değil"
 
-#: extension.js:206
+#: extension.js:208
 msgid "This extension depends on EasyEffects to function"
 msgstr "Bu uzantı çalışmak için EasyEffects'e bağımlıdır"
 
-#: extension.js:324
+#: extension.js:326
 msgid "An error occurred while trying to get available presets"
 msgstr "Mevcut ön ayarlar alınmaya çalışılırken bir hata meydana geldi"
 
-#: preferences/prefsPage.js:32
+#: preferences/prefsPage.js:34
 msgid "Keyboard Shortcuts"
 msgstr "Klavye Kısayolları"
 
-#: preferences/prefsPage.js:40
+#: preferences/prefsPage.js:42
 msgid "Cycle Output Presets"
 msgstr "Çıkış Ön Ayarlarını Çevir"
 
-#: preferences/prefsPage.js:41
+#: preferences/prefsPage.js:43
 msgid "Keyboard shortcut to cycle through output presets"
 msgstr "Çıkış ön ayarları arasında dönmek için klavye kısayolu"
 
-#: preferences/prefsPage.js:47
+#: preferences/prefsPage.js:49
 msgid "Cycle Input Presets"
 msgstr "Giriş Ön Ayarlarını Çevir"
 
-#: preferences/prefsPage.js:48
+#: preferences/prefsPage.js:50
 msgid "Keyboard shortcut to cycle through input presets"
 msgstr "Giriş ön ayarları arasında dönmek için klavye kısayolu"
 
-#: preferences/prefsPage.js:122
+#: preferences/prefsPage.js:124
 msgid "New shortcut…"
 msgstr "Yeni kısayol…"
 
-#: preferences/prefsPage.js:154
+#: preferences/prefsPage.js:156
 msgid "Enter new shortcut…"
 msgstr "Yeni kısayol gir…"
 
-#: preferences/prefsPage.js:155
+#: preferences/prefsPage.js:157
 msgid "Use Backspace to clear"
 msgstr "Temizlemek için Geri Silmeyi kullan"
 

--- a/eepresetselector@ulville.github.io/metadata.json
+++ b/eepresetselector@ulville.github.io/metadata.json
@@ -3,12 +3,7 @@
   "description": "Quickly show and load EasyEffects Presets",
   "uuid": "eepresetselector@ulville.github.io",
   "shell-version": [
-    "3.38",
-    "40",
-    "41",
-    "42",
-    "43",
-    "44"
+    "45"
   ],
   "url": "https://github.com/ulville/eepresetselector",
   "settings-schema": "org.gnome.shell.extensions.eepresetselector",

--- a/eepresetselector@ulville.github.io/preferences/prefsPage.js
+++ b/eepresetselector@ulville.github.io/preferences/prefsPage.js
@@ -15,7 +15,7 @@ import {gettext as _} from 'resource:///org/gnome/Shell/Extensions/js/extensions
 
 const genParam = (type, name, ...dflt) => GObject.ParamSpec[type](name, name, name, GObject.ParamFlags.READWRITE, ...dflt);
 
-var EEPSPrefsPage = GObject.registerClass(
+export var EEPSPrefsPage = GObject.registerClass(
     class EEPSPrefsPage extends Adw.PreferencesPage {
         _init(settings) {
             super._init();

--- a/eepresetselector@ulville.github.io/preferences/prefsPage.js
+++ b/eepresetselector@ulville.github.io/preferences/prefsPage.js
@@ -6,11 +6,13 @@
 
 'use strict';
 
-const { Adw, Gtk, GObject, Gdk } = imports.gi;
+import Adw from 'gi://Adw';
+import Gtk from 'gi://Gtk';
+import GObject from 'gi://GObject';
+import Gdk from 'gi://Gdk';
 
-const ExtensionUtils = imports.misc.extensionUtils;
+import {gettext as _} from 'resource:///org/gnome/Shell/Extensions/js/extensions/prefs.js';
 
-const _ = ExtensionUtils.gettext;
 const genParam = (type, name, ...dflt) => GObject.ParamSpec[type](name, name, name, GObject.ParamFlags.READWRITE, ...dflt);
 
 var EEPSPrefsPage = GObject.registerClass(
@@ -93,7 +95,7 @@ const ShortcutRow = class extends Adw.ActionRow {
                 shortcut: genParam('string', 'shortcut', ''),
             },
             Signals: {
-                changed: { param_types: [GObject.TYPE_STRING] },
+                changed: {param_types: [GObject.TYPE_STRING]},
             },
         }, this);
     }

--- a/eepresetselector@ulville.github.io/prefs.js
+++ b/eepresetselector@ulville.github.io/prefs.js
@@ -1,26 +1,16 @@
 'use strict';
 
-const GETTEXT_DOMAIN = 'gnome-shell-extension-eepresetselector';
+import * as PrefsPage from './preferences/prefsPage.js';
 
-const ExtensionUtils = imports.misc.extensionUtils;
-const Me = ExtensionUtils.getCurrentExtension();
-const PrefsPage = Me.imports.preferences.prefsPage;
+import {ExtensionPreferences, gettext as _} from 'resource:///org/gnome/Shell/Extensions/js/extensions/prefs.js';
 
-const _ = ExtensionUtils.gettext;
+export default class EEPSPreferences extends ExtensionPreferences {
+    fillPreferencesWindow(window) {
+        const settings = this.getSettings();
 
-// eslint-disable-next-line jsdoc/require-jsdoc, no-unused-vars
-function init() {
-    ExtensionUtils.initTranslations(GETTEXT_DOMAIN);
-}
+        const prefsPage = new PrefsPage.EEPSPrefsPage(settings);
 
-// eslint-disable-next-line jsdoc/require-jsdoc, no-unused-vars
-function fillPreferencesWindow(window) {
-    const settings = ExtensionUtils.getSettings();
-
-    const prefsPage = new PrefsPage.EEPSPrefsPage(settings);
-
-    window.add(prefsPage);
-
-    // Make sure the window doesn't outlive the settings object
-    window._settings = settings;
+        window.add(prefsPage);
+        window._settings = settings;
+    }
 }

--- a/eepresetselector@ulville.github.io/prefs.js
+++ b/eepresetselector@ulville.github.io/prefs.js
@@ -4,7 +4,7 @@
 
 import * as PrefsPage from './preferences/prefsPage.js';
 
-import {ExtensionPreferences, gettext as _} from 'resource:///org/gnome/Shell/Extensions/js/extensions/prefs.js';
+import {ExtensionPreferences} from 'resource:///org/gnome/Shell/Extensions/js/extensions/prefs.js';
 
 export default class EEPSPreferences extends ExtensionPreferences {
     fillPreferencesWindow(window) {

--- a/eepresetselector@ulville.github.io/prefs.js
+++ b/eepresetselector@ulville.github.io/prefs.js
@@ -1,3 +1,5 @@
+/* exported EEPSPreferences */
+
 'use strict';
 
 import * as PrefsPage from './preferences/prefsPage.js';

--- a/update-locale.sh
+++ b/update-locale.sh
@@ -9,9 +9,15 @@ xgettext -j ./*.js -o "$pot" --from-code UTF-8
 xgettext -j preferences/*.js -o "$pot" --from-code UTF-8
 xgettext -j schemas/*.xml -o "$pot" --from-code UTF-8
 
-for po in locale/*; do
-    echo "$po"
-    msgmerge --backup=off -U "$po" "$pot"
-done
+if [ $1 = "-a" ]; then
+    echo "Template created as $pot"
+    echo "Use it to create a po file for a new language"
+    echo -e "Don't forget to remove \e[33m$pot\e[0m after you created your .po file"
+else
+    for po in locale/*; do
+        echo "$po"
+        msgmerge --backup=off -U "$po" "$pot"
+    done
 
-rm "$pot"
+    rm "$pot"
+fi

--- a/update-locale.sh
+++ b/update-locale.sh
@@ -9,11 +9,9 @@ xgettext -j ./*.js -o "$pot" --from-code UTF-8
 xgettext -j preferences/*.js -o "$pot" --from-code UTF-8
 xgettext -j schemas/*.xml -o "$pot" --from-code UTF-8
 
-for locale_lang in locale/*; do
-    po="$locale_lang/LC_MESSAGES/gnome-shell-extension-eepresetselector.po"
+for po in locale/*; do
     echo "$po"
     msgmerge --backup=off -U "$po" "$pot"
-    msgfmt "$po" -o "${po%po}mo"
 done
 
 rm "$pot"


### PR DESCRIPTION
This ports the extension to GNOME 45.

GNOME 45 uses ESM modules and they are incompatible with older GNOME versions. From now on, older GNOME versions will be supported in *legacy* branch. Some features and bugfixes will be backported to legacy branch. 

Tested on GNOME OS Nightly in a VM.