### PR TITLE
global bypass toggle

### DIFF
--- a/eepresetselector@ulville.github.io/extension.js
+++ b/eepresetselector@ulville.github.io/extension.js
@@ -181,12 +181,7 @@ const EEPSIndicator = GObject.registerClass(
             this.menu._getMenuItems().forEach(item => {
                 item.destroy();
             });
-            // Add switch menu item to toggle global bypass
-            const toggleBypassItem = new PopupMenu.PopupSwitchMenuItem(_("Enable global bypass"), this.enableBypass, {});
-            toggleBypassItem.connect("toggled", (item, state) => {
-                this._enableGlobalBypass(state);
-            })
-            this.menu.addMenuItem(toggleBypassItem);
+
             // Category Title: "Output Presets" (As how the command did output it)
             if (outputCategoryName)
                 this._addCategoryTitle(outputCategoryName, 'audio-speakers-symbolic');
@@ -205,8 +200,18 @@ const EEPSIndicator = GObject.registerClass(
             let _inputSection = new PopupMenu.PopupMenuSection();
             this._addScrollMenuSection(_inputScrollView, _inputSection, this.inputPresets, this.lastUsedInputPreset, command);
 
+            // Separator
             let _separatorItem = new PopupMenu.PopupSeparatorMenuItem();
             this.menu.addMenuItem(_separatorItem);
+
+            // Add switch menu item to toggle global bypass
+            const toggleBypassItem = new PopupMenu.PopupSwitchMenuItem(_("Global Bypass"), this.enableBypass, {});
+            toggleBypassItem.setOrnament(PopupMenu.Ornament.NONE);
+            toggleBypassItem.add_style_class_name("bypass-toggle-item");
+            toggleBypassItem.connect("toggled", (item, state) => {
+                this._enableGlobalBypass(state);
+            })
+            this.menu.addMenuItem(toggleBypassItem);
 
             // Add a menu item to activate (open) the Easy Effects application
             let _easyEffectsActivatorItem = new PopupMenu.PopupMenuItem(

--- a/eepresetselector@ulville.github.io/extension.js
+++ b/eepresetselector@ulville.github.io/extension.js
@@ -232,17 +232,18 @@ const EEPSIndicator = GObject.registerClass(
             let [, _outputNaturH] = _outputSection.actor.get_preferred_height(-1);
             let [, _inputNaturH] = _inputSection.actor.get_preferred_height(-1);
             let [, _sepNaturH] = _separatorItem.actor.get_preferred_height(-1);
+            let [, _toggleBypassNaturH] = toggleBypassItem.actor.get_preferred_height(-1);
             let [, _eeActNaturH] = _easyEffectsActivatorItem.actor.get_preferred_height(-1);
 
-            let _notFillsScreen = _maxHeight >= 0 && _inputNaturH + _outputNaturH + 2 * _titleNaturH <= _maxHeight - _eeActNaturH - _sepNaturH;
+            let _notFillsScreen = _maxHeight >= 0 && _inputNaturH + _outputNaturH + 2 * _titleNaturH <= _maxHeight - _eeActNaturH - _sepNaturH - _toggleBypassNaturH;
             if (_notFillsScreen) {
                 _inputScrollView.vscrollbar_policy = St.PolicyType.NEVER;
                 _outputScrollView.vscrollbar_policy = St.PolicyType.NEVER;
             } else {
-                let _outputNeedsScrollbar = _maxHeight >= 0 && _outputNaturH + _titleNaturH >= (_maxHeight - _eeActNaturH - _sepNaturH) / 2;
+                let _outputNeedsScrollbar = _maxHeight >= 0 && _outputNaturH + _titleNaturH >= (_maxHeight - _eeActNaturH - _sepNaturH - _toggleBypassNaturH) / 2;
                 _outputScrollView.vscrollbar_policy = _outputNeedsScrollbar ? St.PolicyType.AUTOMATIC : St.PolicyType.NEVER;
 
-                let _inputNeedsScrollbar = _maxHeight >= 0 && _inputNaturH + _titleNaturH >= (_maxHeight - _eeActNaturH - _sepNaturH) / 2;
+                let _inputNeedsScrollbar = _maxHeight >= 0 && _inputNaturH + _titleNaturH >= (_maxHeight - _eeActNaturH - _sepNaturH - _toggleBypassNaturH) / 2;
                 _inputScrollView.vscrollbar_policy = _inputNeedsScrollbar ? St.PolicyType.AUTOMATIC : St.PolicyType.NEVER;
             }
         }

--- a/eepresetselector@ulville.github.io/extension.js
+++ b/eepresetselector@ulville.github.io/extension.js
@@ -120,8 +120,8 @@ const EEPSIndicator = GObject.registerClass(
 
         _enableGlobalBypass(state) {
             this.enableBypass = state;
-            const bypassOption = state ? "1": "2";
-            const command = this.command.concat(["-b", bypassOption]).join(" ");
+            const bypassOption = state ? '1' : '2';
+            const command = this.command.concat(['-b', bypassOption]).join(' ');
             try {
                 GLib.spawn_command_line_async(command);
             } catch (error) {
@@ -205,12 +205,12 @@ const EEPSIndicator = GObject.registerClass(
             this.menu.addMenuItem(_separatorItem);
 
             // Add switch menu item to toggle global bypass
-            const toggleBypassItem = new PopupMenu.PopupSwitchMenuItem(_("Global Bypass"), this.enableBypass, {});
+            const toggleBypassItem = new PopupMenu.PopupSwitchMenuItem(_('Global Bypass'), this.enableBypass, {});
             toggleBypassItem.setOrnament(PopupMenu.Ornament.NONE);
-            toggleBypassItem.add_style_class_name("bypass-toggle-item");
-            toggleBypassItem.connect("toggled", (item, state) => {
+            toggleBypassItem.add_style_class_name('bypass-toggle-item');
+            toggleBypassItem.connect('toggled', (item, state) => {
                 this._enableGlobalBypass(state);
-            })
+            });
             this.menu.addMenuItem(toggleBypassItem);
 
             // Add a menu item to activate (open) the Easy Effects application
@@ -279,10 +279,10 @@ const EEPSIndicator = GObject.registerClass(
 
                 // Get global bypass
                 try {
-                    const bypassResponse = await this.execCommunicate(this.command.concat(["-b", "3"]));
-                    this.enableBypass = (bypassResponse.trim() === "1");
+                    const bypassResponse = await this.execCommunicate(this.command.concat(['-b', '3']));
+                    this.enableBypass = bypassResponse.trim() === '1';
                 } catch (err) {
-                    Main.notify(_("An error occurred while trying to get global bypass"), _(`Error:\n\n${err}`));
+                    Main.notify(_('An error occurred while trying to get global bypass'), _(`Error:\n\n${err}`));
                     logError(err);
                 }
 

--- a/eepresetselector@ulville.github.io/extension.js
+++ b/eepresetselector@ulville.github.io/extension.js
@@ -271,6 +271,15 @@ const EEPSIndicator = GObject.registerClass(
                 // Build menu with last values
                 this._buildMenu(this.categoryNames[0], this.categoryNames[1], this.command);
 
+                // Get global bypass
+                try {
+                    const bypassResponse = await this.execCommunicate(this.command.concat(["-b", "3"]));
+                    this.enableBypass = (bypassResponse.trim() === "1");
+                } catch (err) {
+                    Main.notify(_("An error occurred while trying to get global bypass"), _(`Error:\n\n${err}`));
+                    logError(err);
+                }
+
                 // Try to get Last used presets
                 let erMessage = 'An error occurred while trying to get last presets';
                 try {
@@ -392,11 +401,6 @@ const EEPSIndicator = GObject.registerClass(
                     Main.notify(_(erMessage), _(`Error:\n\n${e}`));
                     logError(e);
                 }
-
-                // Get global bypass
-                const bypassResponse = await this.execCommunicate(this.command.concat(["-b", "3"]));
-                const bypassEnabled = (bypassResponse.trim() === "1")
-                this.enableBypass = bypassEnabled;
             }
         }
 

--- a/eepresetselector@ulville.github.io/stylesheet.css
+++ b/eepresetselector@ulville.github.io/stylesheet.css
@@ -6,3 +6,7 @@
 .easyeffects-activator-item {
     font-weight: bold;
 }
+
+.bypass-toggle-item {
+    font-weight: bold;
+}


### PR DESCRIPTION
This pr adds a toggle button at the top of the menu that can enable/disable global bypass option, which can be useful  when users want to turn on/off the effects from the top panel.